### PR TITLE
[AntiLinks] Match URLs Like x.com

### DIFF
--- a/antilinks/core.py
+++ b/antilinks/core.py
@@ -38,7 +38,7 @@ log: RedTraceLogger = getLogger("red.seinacogs.antilinks")
 RequestType = Literal["discord_deleted_user", "owner", "user", "user_strict"]
 
 LINKS: Pattern[str] = re.compile(
-    r"(\|\|)?(([\w]+:)?\/\/)?(([\d\w]|%[a-fA-f\d]{2,2})+(:([\d\w]|%[a-fA-f\d]{2,2})+)?@)?([\d\w][-\d\w]{0,253}[\d\w]\.)+[\w]{2,63}(:[\d]+)?(\/([-+_~.\d\w]|%[a-fA-f\d]{2,2})*)*(\?(&?([-+_~.\d\w]|%[a-fA-f\d]{2,2})=?)*)?(#([-+_~.\d\w]|%[a-fA-f\d]{2,2})*)?(\|\|)?"  # type: ignore
+    r"(\|\|)?(([\w]+:)?\/\/)?(([\d\w]|%[a-fA-f\d]{2,2})+(:([\d\w]|%[a-fA-f\d]{2,2})+)?@)?([\d\w]?[-\d\w]{0,253}[\d\w]\.)+[\w]{2,63}(:[\d]+)?(\/([-+_~.\d\w]|%[a-fA-f\d]{2,2})*)*(\?(&?([-+_~.\d\w]|%[a-fA-f\d]{2,2})=?)*)?(#([-+_~.\d\w]|%[a-fA-f\d]{2,2})*)?(\|\|)?"  # type: ignore
 )
 
 


### PR DESCRIPTION
The original regex wouldn't match URLs that only have one character before .xxx, such as x.com. I simply add a `?` after `[\d\w]` to make the regex accept domain names started with a single character.

Since Twitter registered x.com as its alternative domain name, many people would use links starting with x.com, and AntiLinks would fail to remove such links (Thanks, Elon!)

Not sure if this change would break other URL matching, but I tested with some other links without encountering any problems.