### PR TITLE
[Animals] fix `{ctx.clean_prefix}` not formatting in the string

### DIFF
--- a/animals/core.py
+++ b/animals/core.py
@@ -120,7 +120,7 @@ class Animals(commands.Cog):
                     embeds=[
                         discord.Embed(
                             description=(
-                                "Invalid breed, use the `{ctx.clean_prefix}cat breeds` "
+                                "Invalid breed, use the `cat breeds` "
                                 "command for the valid breeds."
                             ),
                             color=await ctx.embed_color(),
@@ -209,7 +209,7 @@ class Animals(commands.Cog):
                     embeds=[
                         discord.Embed(
                             description=(
-                                "Invalid breed, use the `{ctx.clean_prefix}dog breeds` "
+                                "Invalid breed, use the `dog breeds` "
                                 "command for the valid breeds."
                             ),
                             color=await ctx.embed_color(),


### PR DESCRIPTION
Shows up like this, kinda looks bad
![image](https://github.com/user-attachments/assets/43ce28a4-a3be-4105-887f-d8f75111d4e2)
