### PR TITLE
[disboardreminder] replaced `interaction` due to it being deprecated

### DIFF
--- a/disboardreminder/core.py
+++ b/disboardreminder/core.py
@@ -325,8 +325,8 @@ class DisboardReminder(commands.Cog):
                     break
         if member_adapter is None:
             member_adapter = (
-                tse.MemberAdapter(message.interaction.user)  # type: ignore
-                if message.interaction
+                tse.MemberAdapter(message.interaction_metadata.user)  # type: ignore
+                if message.interaction_metadata
                 else tse.StringAdapter("Unknown User")
             )
         ty_message = data["ty_message"]


### PR DESCRIPTION
Removed the warning: 
```
           WARNING  [py.warnings] /root/.local/share/Red-DiscordBot/data/axion/cogs/CogManager/cogs/disboardreminder/core.py:328: DeprecationWarning: interaction is deprecated, use interaction_metadata instead.
```
from console logs. Changes have not been tested, but it should not change the way it works, just supress the warning, and not use `interaction` but `interaction_metadata` since it is deprecated.